### PR TITLE
修复可能导致下游库报错 `ValueError: sandoku is not a yaku`

### DIFF
--- a/src/commonMain/kotlin/mahjongutils/yaku/Yakus.kt
+++ b/src/commonMain/kotlin/mahjongutils/yaku/Yakus.kt
@@ -165,7 +165,7 @@ object Yakus {
     /**
      * 三色同刻
      */
-    val Sandoku = Yaku("Sandoku", 2) { pattern ->
+    val Sandoko = Yaku("Sandoko", 2) { pattern ->
         if (pattern !is RegularHoraHandPattern)
             return@Yaku false
 
@@ -358,7 +358,7 @@ object Yakus {
      */
     val allCommonYaku = setOf(
         Tsumo, Pinhu, Tanyao, Ipe, SelfWind, RoundWind, Haku, Hatsu, Chun,
-        Sanshoku, Ittsu, Chanta, Chitoi, Toitoi, Sananko, Honroto, Sandoku, Sankantsu, Shosangen,
+        Sanshoku, Ittsu, Chanta, Chitoi, Toitoi, Sananko, Honroto, Sandoko, Sankantsu, Shosangen,
         Honitsu, Junchan, Ryanpe, Chinitsu
     )
 

--- a/src/jvmTest/kotlin/mahjongutils/yaku/TestYaku.kt
+++ b/src/jvmTest/kotlin/mahjongutils/yaku/TestYaku.kt
@@ -19,7 +19,7 @@ import mahjongutils.yaku.Yakus.Pinhu
 import mahjongutils.yaku.Yakus.RoundWind
 import mahjongutils.yaku.Yakus.Ryanpe
 import mahjongutils.yaku.Yakus.Sananko
-import mahjongutils.yaku.Yakus.Sandoku
+import mahjongutils.yaku.Yakus.Sandoko
 import mahjongutils.yaku.Yakus.Sankantsu
 import mahjongutils.yaku.Yakus.Sanshoku
 import mahjongutils.yaku.Yakus.SelfWind
@@ -266,7 +266,7 @@ internal class TestYaku {
 
 
     @Test
-    fun testSananko_Sandoku() {
+    fun testSananko_Sandoko() {
         val pattern = RegularHoraHandPattern(
             RegularHandPattern(
                 k = 4,
@@ -281,12 +281,12 @@ internal class TestYaku {
             tsumo = false,
         )
 
-        tester(pattern, setOf(Sananko, Sandoku))
+        tester(pattern, setOf(Sananko, Sandoko))
     }
 
 
     @Test
-    fun testSandoku_Sankantsu() {
+    fun testSandoko_Sankantsu() {
         val pattern = RegularHoraHandPattern(
             RegularHandPattern(
                 k = 4,
@@ -301,7 +301,7 @@ internal class TestYaku {
             tsumo = false,
         )
 
-        tester(pattern, setOf(Sandoku, Sankantsu))
+        tester(pattern, setOf(Sandoko, Sankantsu))
     }
 
 


### PR DESCRIPTION
https://github.com/ssttkkl/nonebot-plugin-mahjong-utils/blob/main/src/nonebot_plugin_mahjong_utils/utils/mapper.py#L30